### PR TITLE
Rename Iris -> Aftra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,5 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 
-iris-api
+aftra-api
 dist/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 mkfile_dir:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
 build:
-	go build cli/iris/main.go
+	go build cli/aftra/main.go
 
 upgrade:
 	curl https://app.vikin.gr/api/openapi.json > $(mkfile_dir)/scripts/openapi.json 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
-# iris-api
+# aftra-api
 
-Public API go binary for integration with IRIS
+Public API go binary for integration with AFTRA
 
 Env Variables:
 
-- IRIS_API_TOKEN: Token for communicating with the IRIS api
-- IRIS_COMPANY: Company ID associated with the token (Retrieved using `iris-api get token company`)
+- AFTRA_API_TOKEN: Token for communicating with the AFTRA api
+- AFTRA_COMPANY: Company ID associated with the token (Retrieved using `aftra-api get token company`)
 
-- IRIS_HOST: Location of the host. Used during testing of the CLI client.
-
+- AFTRA_HOST: Location of the host. Used during testing of the CLI client.
 
 ## Rebuilding the openapi-based structs
 
@@ -18,43 +17,42 @@ To add additional items to the subset of openapi schema being used, edit `PATHS`
 
 ## Example usage
 
-| Command                                                            | Description                                                       |
-| ------------------------------------------------------------------ | ----------------------------------------------------------------- |
-| `iris-api create opportunity`                                      | Create an internal opportunity in Iris                            |
-| `iris-api get token`                                               | Get current token information in json format                      |
-| `iris-api get company`                                             | Get current token company information only                        |
-| `iris-api get config <scan-type> <scan-name> `                     | Get a scan config                                                 |
-| `iris-api log <scan-type> <scan-name> <msg>`                       | Log the contents of msg to Iris. It will be viewable viat the API |
-| `your_command.sh \| iris-api log <scan-type> <scan-name>`          | Log from stdout to Iris. It will be viewable viat the API         |
-        
+| Command                                                    | Description                                                       |
+| ---------------------------------------------------------- | ----------------------------------------------------------------- |
+| `aftra-api create opportunity`                             | Create an internal opportunity in Aftra                            |
+| `aftra-api get token`                                      | Get current token information in json format                      |
+| `aftra-api get company`                                    | Get current token company information only                        |
+| `aftra-api get config <scan-type> <scan-name> `            | Get a scan config                                                 |
+| `aftra-api log <scan-type> <scan-name> <msg>`              | Log the contents of msg to Aftra. It will be viewable viat the API |
+| `your_command.sh \| aftra-api log <scan-type> <scan-name>` | Log from stdout to Aftra. It will be viewable viat the API         |
+
 ### Create opportunity
 
 - uid: This should uniquely identify the opportunity. Creating with the same uid will result
   in an update to the existing one.
-- details: Additional information in the form of key,value pairs. These are presented to the user in Iris.
+- details: Additional information in the form of key,value pairs. These are presented to the user in Aftra.
 - name: The display name for the opportunity.
 - score: Risk score (critical, high, medium, low, info, none, unknown)
 
 ## Getting started
 
-1.  Export your token as IRIS_API_TOKEN
+1.  Export your token as AFTRA_API_TOKEN
 
-    `$ export IRIS_API_TOKEN=<token>`
+    `$ export AFTRA_API_TOKEN=<token>`
 
-2.  Export company id as IRIS_COMPANY
+2.  Export company id as AFTRA_COMPANY
 
-    `$ export IRIS_COMPANY=$(iris-api get token company)`
+    `$ export AFTRA_COMPANY=$(aftra-api get token company)`
 
 3.  (Optional) Get any config required, and put somewhere that your script uses. The name is that defined on the
     config via the web UI.
 
-    `$ iris-api get config syndis-scan myscanner > config.ini`
+    `$ aftra-api get config syndis-scan myscanner > config.ini`
 
 4.  Create an opportunity
 
-    `$ iris-api create opportunity --uid=<uid> --name=<name> --score=<score> --details=<details>`
+    `$ aftra-api create opportunity --uid=<uid> --name=<name> --score=<score> --details=<details>`
 
 5.  Log out messages from stdin
 
-    `$ ./my_opportunity_finder.sh | iris-api log syndis-scan myscanner`
-
+    `$ ./my_opportunity_finder.sh | aftra-api log syndis-scan myscanner`

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -15,8 +15,8 @@ import (
 var (
 	createCmd = &cobra.Command{
 		Use:   "create",
-		Short: "Create entities inside Iris",
-		Long: `Use the Iris API to create things.
+		Short: "Create entities inside Aftra",
+		Long: `Use the Aftra API to create things.
 
 You'll need an API key to make this happen`,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/create_opportunity.go
+++ b/cmd/create_opportunity.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	openapi "github.com/syndis-software/iris-api/pkg/openapi"
+	openapi "github.com/syndis-software/aftra-api/pkg/openapi"
 )
 
 // opportunityCmd represents the opportunity command
@@ -22,8 +22,8 @@ var (
 	opportunityCmd = &cobra.Command{
 		Use:          "opportunity",
 		SilenceUsage: true,
-		Short:        "Create internal opportunities inside Iris",
-		Long: `Use the Iris API to create internal opportunities
+		Short:        "Create internal opportunities inside Aftra",
+		Long: `Use the Aftra API to create internal opportunities
 
 	These will become part of the overall picture of your installation.
 	You'll need an API key to make this happen`,

--- a/cmd/create_opportunity_test.go
+++ b/cmd/create_opportunity_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	openapi "github.com/syndis-software/iris-api/pkg/openapi"
+	openapi "github.com/syndis-software/aftra-api/pkg/openapi"
 )
 
 func Test_ExecuteCreateOpportunity(t *testing.T) {

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -13,8 +13,8 @@ import (
 // getCmd represents the get command
 var getCmd = &cobra.Command{
 	Use:   "get",
-	Short: "Get Iris resources (eg tokens)",
-	Long:  `Get Iris resources via the API`,
+	Short: "Get Aftra resources (eg tokens)",
+	Long:  `Get Aftra resources via the API`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Fprint(cmd.ErrOrStderr(), "Error: must also specify a command")
 	},

--- a/cmd/get_company.go
+++ b/cmd/get_company.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	openapi "github.com/syndis-software/iris-api/pkg/openapi"
+	openapi "github.com/syndis-software/aftra-api/pkg/openapi"
 )
 
 // companyCmd represents the company command
@@ -18,7 +18,7 @@ var getCompanyCmd = &cobra.Command{
 	Long: `Get the company associated with this token
 	
 Some commands require a company id. Use this command to get the company from the 
-API. This can be then set as the environment variable IRIS_COMPANY for future use.
+API. This can be then set as the environment variable AFTRA_COMPANY for future use.
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()

--- a/cmd/get_config.go
+++ b/cmd/get_config.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	openapi "github.com/syndis-software/iris-api/pkg/openapi"
+	openapi "github.com/syndis-software/aftra-api/pkg/openapi"
 )
 
 // getCmd represents the get command

--- a/cmd/get_token.go
+++ b/cmd/get_token.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	openapi "github.com/syndis-software/iris-api/pkg/openapi"
+	openapi "github.com/syndis-software/aftra-api/pkg/openapi"
 )
 
 // tokenCmd represents the token command

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	openapi "github.com/syndis-software/iris-api/pkg/openapi"
+	openapi "github.com/syndis-software/aftra-api/pkg/openapi"
 )
 
 // logCmd represents the log command
@@ -23,9 +23,9 @@ var (
 		Short: "Submit a log message for the current token",
 		Long: `Submit a log message for the current token
 	
-Log messages can be viewed against the token in the Iris UI. This can provide a
+Log messages can be viewed against the token in the Aftra UI. This can provide a
 useful feedback loop if you are configuring your token-using-application via
-the token config in iris. Simply pass in any string and it will appear there.
+the token config in aftra. Simply pass in any string and it will appear there.
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()

--- a/cmd/log_test.go
+++ b/cmd/log_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/syndis-software/iris-api/pkg/openapi"
+	"github.com/syndis-software/aftra-api/pkg/openapi"
 )
 
 func Test_ExecuteLog_Single(t *testing.T) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,17 +12,17 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	openapi "github.com/syndis-software/iris-api/pkg/openapi"
+	openapi "github.com/syndis-software/aftra-api/pkg/openapi"
 )
 
 // rootCmd represents the base command when called without any subcommands
 var (
 	// Used for flags
 	rootCmd = &cobra.Command{
-		Use:          "iris-api",
+		Use:          "aftra-api",
 		SilenceUsage: true,
-		Short:        "CLI for the Iris API",
-		Long:         `CLI for using the IRIS API`,
+		Short:        "CLI for the Aftra API",
+		Long:         `CLI for using the AFTRA API`,
 
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Fprint(cmd.ErrOrStderr(), "Error: must also specify a command")
@@ -57,12 +57,12 @@ func Execute(ctx context.Context, doer openapi.HttpRequestDoer) {
 
 func init() {
 
-	rootCmd.PersistentFlags().String("host", "https://app.vikin.gr", "Iris host (IRIS_HOST)")
-	rootCmd.PersistentFlags().String("company", "", "Company ID. Should look like Company-XXXX (IRIS_COMPANY)")
+	rootCmd.PersistentFlags().String("host", "https://app.vikin.gr", "Aftra host (AFTRA_HOST)")
+	rootCmd.PersistentFlags().String("company", "", "Company ID. Should look like Company-XXXX (AFTRA_COMPANY)")
 	viper.BindPFlag("company", rootCmd.PersistentFlags().Lookup("company"))
 	viper.BindPFlag("host", rootCmd.PersistentFlags().Lookup("host"))
 
-	viper.SetEnvPrefix("iris")
+	viper.SetEnvPrefix("aftra")
 	viper.AutomaticEnv()
 
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/syndis-software/iris-api
+module github.com/syndis-software/aftra-api
 
 go 1.18
 

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/syndis-software/iris-api/cmd"
+	"github.com/syndis-software/aftra-api/cmd"
 )
 
 func main() {


### PR DESCRIPTION
https://aftra.io/ is the new brand name.

This renames all variables and entities from `iris`.

The repo will be renamed shortly 