### PR TITLE
Push raw nessus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ build:
 	go build cli/aftra/main.go
 
 upgrade:
-	curl https://app.vikin.gr/api/openapi.json > $(mkfile_dir)/scripts/openapi.json 
+	curl https://app.aftra.io/api/openapi.json > $(mkfile_dir)/scripts/openapi.json 
 	python $(mkfile_dir)/scripts/subset_maker.py $(mkfile_dir)/scripts/openapi.json > $(mkfile_dir)/scripts/openapi-subset.json
 	oapi-codegen --package=openapi -generate=types,client -o $(mkfile_dir)/pkg/openapi/openapi.gen.go $(mkfile_dir)/scripts/openapi-subset.json
 	rm $(mkfile_dir)/scripts/openapi.json

--- a/README.md
+++ b/README.md
@@ -17,12 +17,13 @@ To add additional items to the subset of openapi schema being used, edit `PATHS`
 
 ## Example usage
 
-| Command                                                    | Description                                                       |
-| ---------------------------------------------------------- | ----------------------------------------------------------------- |
+| Command                                                    | Description                                                        |
+| ---------------------------------------------------------- | -------------------------------------------------------------------|
 | `aftra-api create opportunity`                             | Create an internal opportunity in Aftra                            |
-| `aftra-api get token`                                      | Get current token information in json format                      |
-| `aftra-api get company`                                    | Get current token company information only                        |
-| `aftra-api get config <scan-type> <scan-name> `            | Get a scan config                                                 |
+| `aftra-api submit <scan-type> <scan-name> <msg>`           | Submit a raw scan event to the specified scanner                   |
+| `aftra-api get token`                                      | Get current token information in json format                       |
+| `aftra-api get company`                                    | Get current token company information only                         |
+| `aftra-api get config <scan-type> <scan-name> `            | Get a scan config                                                  |
 | `aftra-api log <scan-type> <scan-name> <msg>`              | Log the contents of msg to Aftra. It will be viewable viat the API |
 | `your_command.sh \| aftra-api log <scan-type> <scan-name>` | Log from stdout to Aftra. It will be viewable viat the API         |
 

--- a/cmd/create_opportunity.go
+++ b/cmd/create_opportunity.go
@@ -78,7 +78,7 @@ func init() {
 	createCmd.AddCommand(opportunityCmd)
 	opportunityCmd.Flags().StringVar(&uid, "uid", "", "Unique identifier for the opportunity")
 	opportunityCmd.Flags().StringVar(&name, "name", "", "Name of the opportunity")
-	opportunityCmd.Flags().StringVar(&score, "score", string(openapi.Unknown), "Risk score of the opportunity (critical, high, medium, low, info, none, unknown)")
+	opportunityCmd.Flags().StringVar(&score, "score", string(openapi.OpportunityScoreUnknown), "Risk score of the opportunity (critical, high, medium, low, info, none, unknown)")
 	opportunityCmd.Flags().StringVar(&detailsStr, "details", "", "Additional details. Comma separated key=value pairs.")
 	opportunityCmd.MarkFlagRequired("uid")
 	opportunityCmd.MarkFlagRequired("name")

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -20,12 +20,12 @@ var (
 	logCmd = &cobra.Command{
 		Use:   "log [scan-type] [scan-name]",
 		Args:  cobra.MatchAll(cobra.RangeArgs(2, 3), cobra.OnlyValidArgs),
-		Short: "Submit a log message for the current token",
-		Long: `Submit a log message for the current token
+		Short: "Submit a log message for the given scan integration.",
+		Long: `Submit a log message for the given scan integration.
 	
-Log messages can be viewed against the token in the Aftra UI. This can provide a
+Log messages can be viewed against the scanner in the Aftra UI. This can provide a
 useful feedback loop if you are configuring your token-using-application via
-the token config in aftra. Simply pass in any string and it will appear there.
+the config in aftra. Simply pass in any string and it will appear there.
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -12,17 +12,15 @@ import (
 	openapi "github.com/syndis-software/aftra-api/pkg/openapi"
 )
 
-// logCmd represents the log command
 var (
 	submitCmd = &cobra.Command{
-		Use:   "submit [scan-type] [scan-name]",
+		Use:   "submit [scan-type] [scan-name] [scan-result]",
 		Args:  cobra.MatchAll(cobra.ExactArgs(3), cobra.OnlyValidArgs),
-		Short: "Submit a log message for the current token",
-		Long: `Submit a log message for the current token
+		Short: "Submit a json formatted scan result",
+		Long: `Submit a json formatted scan result
 	
-Log messages can be viewed against the token in the Aftra UI. This can provide a
-useful feedback loop if you are configuring your token-using-application via
-the token config in aftra. Simply pass in any string and it will appear there.
+Submit a scan result in the format for given scan-type. For example in
+nessus format for syndis scans.
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
@@ -32,7 +30,8 @@ the token config in aftra. Simply pass in any string and it will appear there.
 			switch {
 			case ScanType(scanType) == syndis:
 
-				// Log a single message
+				// Submit a set of scan events
+
 				var scans []openapi.SyndisInternalScanEvent
 				err := json.Unmarshal([]byte(message), &scans)
 

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -1,0 +1,61 @@
+/*
+Copyright © 2023 Syndis ehf. <syndis@syndis.is>
+
+*/
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	openapi "github.com/syndis-software/aftra-api/pkg/openapi"
+)
+
+// logCmd represents the log command
+var (
+	submitCmd = &cobra.Command{
+		Use:   "submit [scan-type] [scan-name]",
+		Args:  cobra.MatchAll(cobra.ExactArgs(3), cobra.OnlyValidArgs),
+		Short: "Submit a log message for the current token",
+		Long: `Submit a log message for the current token
+	
+Log messages can be viewed against the token in the Aftra UI. This can provide a
+useful feedback loop if you are configuring your token-using-application via
+the token config in aftra. Simply pass in any string and it will appear there.
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			client := ctx.Value(clientKey).(*openapi.ClientWithResponses)
+			scanType, scanName, message := args[0], args[1], args[2]
+
+			switch {
+			case ScanType(scanType) == syndis:
+
+				// Log a single message
+				var scans []openapi.SyndisInternalScanEvent
+				err := json.Unmarshal([]byte(message), &scans)
+
+				if err != nil {
+					return err
+				}
+
+				resp, err := client.SubmitScanResults(ctx, scanName, scans)
+
+				if err != nil {
+					return err
+				}
+
+				return openapi.CheckStatus(resp)
+			default:
+				return fmt.Errorf("unrecognised scan type %s", scanType)
+			}
+
+		},
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(submitCmd)
+
+}

--- a/cmd/submit_test.go
+++ b/cmd/submit_test.go
@@ -1,0 +1,155 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/syndis-software/aftra-api/pkg/openapi"
+)
+
+func Test_ExecuteSubmit_Single_ServerResponseHandling(t *testing.T) {
+	type test struct {
+		serverResponse        int
+		serverResponseContent string
+		expectedOutput        string
+		errorExpected         bool
+	}
+
+	tests := map[string]test{
+		"success": {
+			serverResponse:        200,
+			serverResponseContent: "",
+			expectedOutput:        "",
+			errorExpected:         false,
+		},
+		// "401": {
+		// 	serverResponse:        401,
+		// 	serverResponseContent: "",
+		// 	expectedOutput:        "Error: unauthorized\n",
+		// 	errorExpected:         true},
+		// "403": {
+		// 	serverResponse:        403,
+		// 	serverResponseContent: "",
+		// 	expectedOutput:        "Error: forbidden\n",
+		// 	errorExpected:         true},
+		// "422": {
+		// 	serverResponse:        422,
+		// 	serverResponseContent: "{\"detail\":[{\"loc\":[\"body\",0,\"messages\"],\"msg\":\"field required\",\"type\":\"value_error.missing\"}]}",
+		// 	expectedOutput:        "Error: validation error: [{\"loc\":[\"body\",0,\"messages\"],\"msg\":\"field required\",\"type\":\"value_error.missing\"}]\n",
+		// 	errorExpected:         true,
+		// },
+		// "500": {
+		// 	serverResponse:        500,
+		// 	serverResponseContent: "",
+		// 	expectedOutput:        "Error: server error: 500\n",
+		// 	errorExpected:         true},
+	}
+
+	header := make(http.Header, 1)
+	header.Set("Content-Type", "application/json")
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			mockDoer := &MockHTTP{
+				Response: http.Response{
+					StatusCode: tc.serverResponse,
+					Status:     "",
+					Body:       ioutil.NopCloser(bytes.NewBufferString(tc.serverResponseContent)),
+					Header:     header,
+				},
+				ResponseError: nil,
+			}
+			actual := new(bytes.Buffer)
+			rootCmd.SetOut(actual)
+			rootCmd.SetErr(actual)
+			rootCmd.SetArgs([]string{"submit", "syndis", "scan-name", `[{"folder_name":"Islenskur_Texti","scan_id":"117","scan_uuid":"d776c35d-7d0e-b699-d035-a0120d2dfe28a871ce19964f5207","scan_start":"2023-04-04 08:25:22","scan_end":"2023-04-04 08:32:35","file_name":"External.csv","plugin_id":10114,"cve":"CVE-1999-0524","cvss":0,"risk":"None","host":"153.92.147.3","protocol":"icmp","port":"0","name":"ICMP Timestamp Request Remote Date Disclosure","synopsis":"It is possible to determine the exact time set on the remote host.","description":"The remote host answers to an ICMP timestamp request.  This allows an\nattacker to know the date that is set on the targeted machine, which\nmay assist an unauthenticated, remote attacker in defeating time-based\nauthentication protocols.\n\nTimestamps returned from machines running Windows Vista / 7 / 2008 /\n2008 R2 are deliberately incorrect, but usually within 1000 seconds of\nthe actual system time.","solution":"Filter out the ICMP timestamp requests (13), and the outgoing ICMP\\ntimestamp replies (14).","see_also":"","plugin_output":"The remote clock is synchronized with the local clock.\\n","stig_severity":"","cvss_v3_0_base_score":0,"cvss_temporal_score":0,"cvss_v3_0_temporal_score":0,"risk_factor":"None","bid":"","xref":"CWE:200","mskb":"","plugin_publication_date":"1999/08/01","plugin_modification_date":"2019/10/04","metasploit":"","core_impact":"","canvas":""}]`})
+
+			ctx := context.WithValue(context.Background(), doerKey, mockDoer)
+			submitCmd.SetContext(ctx)
+
+			err := rootCmd.ExecuteContext(ctx)
+
+			if tc.errorExpected {
+				assert.NotNil(t, err)
+			} else {
+				assert.Equal(t, nil, err)
+			}
+
+			assert.Equal(t, len(mockDoer.Requests), 1)
+
+			body, _ := ioutil.ReadAll(mockDoer.Requests[0].Body)
+			var submitted []openapi.SyndisInternalScanEvent
+			_ = json.Unmarshal(body, &submitted)
+
+			assert.Equal(t, 1, len(submitted))
+			assert.Equal(t, tc.expectedOutput, actual.String())
+		})
+	}
+
+}
+
+func Test_ExecuteSubmit_Single_JsonParsing(t *testing.T) {
+	type test struct {
+		message        string
+		expectedOutput string
+		errorExpected  bool
+	}
+
+	tests := map[string]test{
+		"success": {
+			message:        "[{}]",
+			expectedOutput: "",
+			errorExpected:  false,
+		},
+		"malformed-json": {
+			message:        "ooo",
+			expectedOutput: "Error: invalid character 'o' looking for beginning of value\n",
+			errorExpected:  true,
+		},
+	}
+
+	header := make(http.Header, 1)
+	header.Set("Content-Type", "application/json")
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			mockDoer := &MockHTTP{
+				Response: http.Response{
+					StatusCode: 200,
+					Status:     "",
+					Body:       ioutil.NopCloser(bytes.NewBufferString("")),
+					Header:     header,
+				},
+				ResponseError: nil,
+			}
+			actual := new(bytes.Buffer)
+			rootCmd.SetOut(actual)
+			rootCmd.SetErr(actual)
+			rootCmd.SetArgs([]string{"submit", "syndis", "scan-name", tc.message})
+
+			ctx := context.WithValue(context.Background(), doerKey, mockDoer)
+			submitCmd.SetContext(ctx)
+
+			err := rootCmd.ExecuteContext(ctx)
+
+			var expectedRequests int
+
+			if tc.errorExpected {
+				assert.NotNil(t, err)
+				expectedRequests = 0
+			} else {
+				assert.Equal(t, nil, err)
+				expectedRequests = 1
+			}
+
+			assert.Equal(t, expectedRequests, len(mockDoer.Requests))
+			assert.Equal(t, tc.expectedOutput, actual.String())
+		})
+	}
+
+}

--- a/cmd/submit_test.go
+++ b/cmd/submit_test.go
@@ -27,27 +27,27 @@ func Test_ExecuteSubmit_Single_ServerResponseHandling(t *testing.T) {
 			expectedOutput:        "",
 			errorExpected:         false,
 		},
-		// "401": {
-		// 	serverResponse:        401,
-		// 	serverResponseContent: "",
-		// 	expectedOutput:        "Error: unauthorized\n",
-		// 	errorExpected:         true},
-		// "403": {
-		// 	serverResponse:        403,
-		// 	serverResponseContent: "",
-		// 	expectedOutput:        "Error: forbidden\n",
-		// 	errorExpected:         true},
-		// "422": {
-		// 	serverResponse:        422,
-		// 	serverResponseContent: "{\"detail\":[{\"loc\":[\"body\",0,\"messages\"],\"msg\":\"field required\",\"type\":\"value_error.missing\"}]}",
-		// 	expectedOutput:        "Error: validation error: [{\"loc\":[\"body\",0,\"messages\"],\"msg\":\"field required\",\"type\":\"value_error.missing\"}]\n",
-		// 	errorExpected:         true,
-		// },
-		// "500": {
-		// 	serverResponse:        500,
-		// 	serverResponseContent: "",
-		// 	expectedOutput:        "Error: server error: 500\n",
-		// 	errorExpected:         true},
+		"401": {
+			serverResponse:        401,
+			serverResponseContent: "",
+			expectedOutput:        "Error: unauthorized\n",
+			errorExpected:         true},
+		"403": {
+			serverResponse:        403,
+			serverResponseContent: "",
+			expectedOutput:        "Error: forbidden\n",
+			errorExpected:         true},
+		"422": {
+			serverResponse:        422,
+			serverResponseContent: "{\"detail\":[{\"loc\":[\"body\",0,\"messages\"],\"msg\":\"field required\",\"type\":\"value_error.missing\"}]}",
+			expectedOutput:        "Error: validation error: [{\"loc\":[\"body\",0,\"messages\"],\"msg\":\"field required\",\"type\":\"value_error.missing\"}]\n",
+			errorExpected:         true,
+		},
+		"500": {
+			serverResponse:        500,
+			serverResponseContent: "",
+			expectedOutput:        "Error: server error: 500\n",
+			errorExpected:         true},
 	}
 
 	header := make(http.Header, 1)

--- a/scripts/subset_maker.py
+++ b/scripts/subset_maker.py
@@ -51,6 +51,7 @@ PATHS = [
     "paths./api/token/.get",
     "paths./api/integrations/syndis-scan/{scan_name}/config.get",
     "paths./api/integrations/syndis-scan/{scan_name}/logs.post",
+    "paths./api/integrations/syndis-scan/{scan_name}/scan.post",
     "components.schemas.MaskedToken",
     "components.schemas.SubmitLogEvent",
     "components.schemas.CreateOpportunity",
@@ -59,6 +60,8 @@ PATHS = [
     "components.schemas.ValidationError",
     "components.schemas.SyndisScanTypes",
     "components.schemas.SyndisScanConfig",
+    "components.schemas.SyndisInternalScanEvent",
+    "components.schemas.SyndisRiskScore",
 ]
 
 


### PR DESCRIPTION
Using the new aftra API to push raw entries via a new subcommand:

```
aftra-api submit <scan-type> <scan-name> <msg>
```

Won't work until https://github.com/syndis-software/vikingr/pull/1618 is merged and deployed to production