### PR TITLE
Generate new openapi spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 
 aftra-cli
 dist/
+/scripts/__pycache__/

--- a/cmd/create_opportunity.go
+++ b/cmd/create_opportunity.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -71,7 +72,12 @@ func stringToMap(str string) (map[string]openapi.CreateOpportunity_Details_Addit
 
 		// add the key-value pair to the map
 		r := openapi.CreateOpportunity_Details_AdditionalProperties{}
-		err := r.FromCreateOpportunityDetails0(kv[1])
+		var err error
+		if v_int, err := strconv.Atoi(kv[1]); err == nil {
+			err = r.FromCreateOpportunityDetails1(v_int)
+		} else {
+			err = r.FromCreateOpportunityDetails0(kv[1])
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/create_opportunity.go
+++ b/cmd/create_opportunity.go
@@ -27,7 +27,10 @@ var (
 	These will become part of the overall picture of your installation.
 	You'll need an API key to make this happen`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			details := stringToMap(detailsStr)
+			details, err := stringToMap(detailsStr)
+			if err != nil {
+				return err
+			}
 
 			opportunity := openapi.CreateOpportunity{
 				Name:    name,
@@ -39,7 +42,7 @@ var (
 			ctx := cmd.Context()
 			client := ctx.Value(clientKey).(*openapi.ClientWithResponses)
 			company := ctx.Value(companyKey).(string)
-			err := openapi.DoCreateOpportunity(ctx, client, company, opportunity)
+			err = openapi.DoCreateOpportunity(ctx, client, company, opportunity)
 
 			if err != nil {
 				return err
@@ -51,8 +54,8 @@ var (
 	}
 )
 
-func stringToMap(str string) map[string]string {
-	result := make(map[string]string)
+func stringToMap(str string) (map[string]openapi.CreateOpportunity_Details_AdditionalProperties, error) {
+	result := make(map[string]openapi.CreateOpportunity_Details_AdditionalProperties)
 
 	// split the string into key-value pairs
 	pairs := strings.Split(str, ",")
@@ -67,10 +70,15 @@ func stringToMap(str string) map[string]string {
 		}
 
 		// add the key-value pair to the map
-		result[kv[0]] = kv[1]
+		r := openapi.CreateOpportunity_Details_AdditionalProperties{}
+		err := r.FromCreateOpportunityDetails0(kv[1])
+		if err != nil {
+			return nil, err
+		}
+		result[kv[0]] = r
 	}
 
-	return result
+	return result, nil
 }
 
 func init() {

--- a/cmd/create_opportunity_test.go
+++ b/cmd/create_opportunity_test.go
@@ -64,15 +64,20 @@ func Test_ExecuteCreateOpportunity(t *testing.T) {
 func Test_ExecuteCreateOpportunityDetails(t *testing.T) {
 	type test struct {
 		details                  string
-		expectedDetailsSubmitted map[string]string
+		expectedDetailsSubmitted map[string]openapi.CreateOpportunity_Details_AdditionalProperties
 	}
 
+	one := openapi.CreateOpportunity_Details_AdditionalProperties{}
+	one.FromCreateOpportunityDetails0("one")
+	two := openapi.CreateOpportunity_Details_AdditionalProperties{}
+	two.FromCreateOpportunityDetails1(2)
+
 	tests := map[string]test{
-		"notgiven":  {details: "", expectedDetailsSubmitted: map[string]string{}},
-		"empty":     {details: "--details=", expectedDetailsSubmitted: map[string]string{}},
-		"single":    {details: "--details=a=1", expectedDetailsSubmitted: map[string]string{"a": "1"}},
-		"double":    {details: "--details=a=1,b=2", expectedDetailsSubmitted: map[string]string{"a": "1", "b": "2"}},
-		"duplicate": {details: "--details=a=1,a=2", expectedDetailsSubmitted: map[string]string{"a": "2"}},
+		"notgiven":  {details: "", expectedDetailsSubmitted: map[string]openapi.CreateOpportunity_Details_AdditionalProperties{}},
+		"empty":     {details: "--details=", expectedDetailsSubmitted: map[string]openapi.CreateOpportunity_Details_AdditionalProperties{}},
+		"single":    {details: "--details=a=one", expectedDetailsSubmitted: map[string]openapi.CreateOpportunity_Details_AdditionalProperties{"a": one}},
+		"double":    {details: "--details=a=one,b=2", expectedDetailsSubmitted: map[string]openapi.CreateOpportunity_Details_AdditionalProperties{"a": one, "b": two}},
+		"duplicate": {details: "--details=a=one,a=2", expectedDetailsSubmitted: map[string]openapi.CreateOpportunity_Details_AdditionalProperties{"a": two}},
 	}
 
 	for name, tc := range tests {

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -28,7 +28,7 @@ var (
 		Args:  cobra.MatchAll(cobra.ExactArgs(2), cobra.OnlyValidArgs),
 		Short: "Submit a json formatted scan result",
 		Long: `Submit a json formatted scan result
-	
+
 Submit a scan result in the format for given scan-type. For example in
 nessus format for syndis scans.
 `,

--- a/go.mod
+++ b/go.mod
@@ -4,29 +4,30 @@ go 1.18
 
 require (
 	github.com/deepmap/oapi-codegen v1.12.4
+	github.com/oapi-codegen/runtime v1.0.0
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.15.0
-	github.com/stretchr/testify v1.8.2
+	github.com/stretchr/testify v1.8.4
 )
 
 require (
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
-	github.com/google/uuid v1.3.0 // indirect
+	github.com/google/uuid v1.3.1 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
-	github.com/pelletier/go-toml/v2 v2.0.6 // indirect
+	github.com/pelletier/go-toml/v2 v2.0.9 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/afero v1.9.3 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
-	golang.org/x/sys v0.3.0 // indirect
-	golang.org/x/text v0.5.0 // indirect
+	golang.org/x/sys v0.11.0 // indirect
+	golang.org/x/text v0.12.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -190,6 +190,7 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/subosito/gotenv v1.4.2 h1:X1TuBLAMDFbaTAChgCBLu3DU3UPyELpnF2jjJ2cz/S8=
 github.com/subosito/gotenv v1.4.2/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=

--- a/go.sum
+++ b/go.sum
@@ -122,6 +122,8 @@ github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm4
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.1 h1:KjJaJ9iWZ3jOFZIf1Lqf4laDRCasjl0BCmnEGxkdLb4=
+github.com/google/uuid v1.3.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
@@ -148,8 +150,12 @@ github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0V
 github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/oapi-codegen/runtime v1.0.0 h1:P4rqFX5fMFWqRzY9M/3YF9+aPSPPB06IzP2P7oOxrWo=
+github.com/oapi-codegen/runtime v1.0.0/go.mod h1:LmCUMQuPB4M/nLXilQXhHw+BLZdDb18B34OO356yJ/A=
 github.com/pelletier/go-toml/v2 v2.0.6 h1:nrzqCb7j9cDFj2coyLNLaZuJTLjWjlaz6nvTvIwycIU=
 github.com/pelletier/go-toml/v2 v2.0.6/go.mod h1:eumQOmlWiOPt5WriQQqoM5y18pDHwha2N+QD+EUNTek=
+github.com/pelletier/go-toml/v2 v2.0.9 h1:uH2qQXheeefCCkuBBSLi7jCiSmj3VRh2+Goq2N7Xxu0=
+github.com/pelletier/go-toml/v2 v2.0.9/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -184,6 +190,7 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/subosito/gotenv v1.4.2 h1:X1TuBLAMDFbaTAChgCBLu3DU3UPyELpnF2jjJ2cz/S8=
 github.com/subosito/gotenv v1.4.2/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -323,6 +330,8 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.3.0 h1:w8ZOecv6NaNa/zC8944JTU3vz4u6Lagfk4RPQxv92NQ=
 golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.11.0 h1:eG7RXZHdqOJ1i+0lgLgCpSXAp6M3LYlAo6osgSi0xOM=
+golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -332,6 +341,8 @@ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.5.0 h1:OLmvp0KP+FVG99Ct/qFiL/Fhk4zp4QQnZ7b2U+5piUM=
 golang.org/x/text v0.5.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
+golang.org/x/text v0.12.0 h1:k+n5B8goJNdU7hSvEtMUz3d1Q6D/XW4COJSJR6fN0mc=
+golang.org/x/text v0.12.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/scripts/test_subset_maker.py
+++ b/scripts/test_subset_maker.py
@@ -1,0 +1,72 @@
+import pytest
+from subset_maker import fix_anyof_null, get_subset
+
+
+def test_get_subset():
+    basic_data = {"a": 1, "b": {"c": 3, "d": 4, "e": {"e1": "1"}}}
+    openapi_like_data = {
+        "paths": {"/some/url": {"get": {"get-stuff": 1}, "post": {"post-stuff": 2}}}
+    }
+    for input, paths, expected in [
+        (
+            basic_data,
+            ["a", "b.d"],
+            {"a": 1, "b": {"d": 4}},
+        ),
+        (basic_data, ["b.e"], {"b": {"e": {"e1": "1"}}}),
+        (basic_data, ["b.c", "b.d"], {"b": {"c": 3, "d": 4}}),
+        (
+            openapi_like_data,
+            ["paths./some/url.post"],
+            {"paths": {"/some/url": {"post": {"post-stuff": 2}}}},
+        ),
+    ]:
+        result = get_subset(input, paths, exclude_paths=[])
+        assert result == expected, f"Failure. Actual {result}; Expected {expected}"
+
+
+@pytest.mark.parametrize(
+    ["schema", "expected_schema"],
+    [
+        (
+            {
+                "anyOf": [
+                    {
+                        "type": "string",
+                    },
+                    {"type": "null"},
+                ],
+            },
+            {"type": "string"},
+        ),
+        (
+            {"type": "string"},
+            {"type": "string"},
+        ),
+    ],
+)
+def test_fix_anyof_null(schema, expected_schema):
+    data = {
+        "paths": {
+            "/path": {
+                "method": {
+                    "parameters": [
+                        {"schema": schema},
+                    ]
+                }
+            }
+        }
+    }
+    expected = {
+        "paths": {
+            "/path": {
+                "method": {
+                    "parameters": [
+                        {"schema": expected_schema},
+                    ]
+                }
+            }
+        }
+    }
+    fix_anyof_null(data)
+    assert data == expected


### PR DESCRIPTION
Openapi spec generation was failing as some parameters are being annotated as `anyOf[str, null]`. Manually remove null from these types.